### PR TITLE
Update autofit_xgboost.json

### DIFF
--- a/configs/autofit_xgboost.json
+++ b/configs/autofit_xgboost.json
@@ -20,12 +20,12 @@
             "learning_rate": 0.05,
             "objective": "binary:logistic",
             "booster": "gbtree",
-            "n_jobs": 1
+            "n_jobs": 1,
+            "random_state": 2333
         },
         "fit_params":{
             "eval_metric": "auc",
-            "early_stopping_rounds": 50,
-            "random_state": 2333
+            "early_stopping_rounds": 50
         }
 
     }


### PR DESCRIPTION
Moves random_state to model_params
xgboost fit method doesn't get random_state as a parameter